### PR TITLE
Fix support for recent versions of Instruments.

### DIFF
--- a/lib/converter-instruments.js
+++ b/lib/converter-instruments.js
@@ -4,7 +4,7 @@ var cpuprofile  = require('./cpuprofile')
   , traceUtil   = require('./trace-util')
   , roi         = require('./remove-optimization-info')
   , Converter   = require('./converter').proto
-  , headerRegex = /^Running Time, *Self,.*, *Symbol Name/
+  , headerRegex = /^Running Time, *Self[^,]*,.*, *Symbol Name/
 
 /*
  * Totally different from the other converters since the data is a callgraph.

--- a/lib/get-converter.js
+++ b/lib/get-converter.js
@@ -6,7 +6,7 @@ var dtraceConverterCtr      = require('./converter-dtrace')
 
 var dtraceRegex = /^\S+ \d+ \d+: \S+:\s*$/
   , perfRegex = /^\S+ \d+ \d+\.\d+:(\s+\d+)? \S+:\s*$/
-  , instrumentsRegex = /^Running Time, *Self,.*, *Symbol Name/
+  , instrumentsRegex = /^Running Time, *Self[^,]*,.*, *Symbol Name/
 
 var go = module.exports = function getConverter(trace, traceStart, type) {
   if (type) {

--- a/test/get-converter.js
+++ b/test/get-converter.js
@@ -33,8 +33,13 @@ test('\ngiven any string and overriding type to be perf', function (t) {
 })
 
 test('\ngiven a instruments stack info line', function (t) {
-  var fn = getConverter([ 'Running Time,Self,,Symbol Name' ], 0);
-  t.equal(fn.name, 'InstrumentsConverter', 'returns instruments converter')
-  t.equal(fn.proto.type, 'instruments', 'type is instruments')
+  var fns = [
+      getConverter([ 'Running Time,Self,,Symbol Name' ], 0),
+      getConverter([ 'Running Time,Self (ms),,Symbol Name' ], 0)
+  ];
+  fns.forEach(function (fn) {
+      t.equal(fn.name, 'InstrumentsConverter', 'returns instruments converter')
+      t.equal(fn.proto.type, 'instruments', 'type is instruments')
+  });
   t.end()
 })


### PR DESCRIPTION
This fixes an detection error I'm getting from Instruments callgraphs. Probably after an update of XCode & friends.

```
Error: Unable to detect input type for "Running Time,Self (ms),,Symbol Name
```

Seems the `(ms)` part has been added.
