### PR TITLE
Support perf 4.4.8 defaults

### DIFF
--- a/lib/get-converter.js
+++ b/lib/get-converter.js
@@ -5,7 +5,7 @@ var dtraceConverterCtr      = require('./converter-dtrace')
   , instrumentsConverterCtr = require('./converter-instruments')
 
 var dtraceRegex = /^\S+ \d+ \d+: \S+:\s*$/
-  , perfRegex = /^\S+ \d+ \d+\.\d+:(\s+\d+)? \S+:\s*$/
+  , perfRegex = /^\S+\s+\d+(\s+\[\d+\])?\s+\d+\.\d+:(\s+\d+)? \S+:\s*$/
   , instrumentsRegex = /^Running Time, *Self,.*, *Symbol Name/
 
 var go = module.exports = function getConverter(trace, traceStart, type) {
@@ -21,8 +21,8 @@ var go = module.exports = function getConverter(trace, traceStart, type) {
   var line = trace[traceStart];
 
   if (dtraceRegex.test(line)) return dtraceConverterCtr;
-  if (perfRegex.test(line)) return perfConverterCtr; 
-  if (instrumentsRegex.test(line)) return instrumentsConverterCtr; 
+  if (perfRegex.test(line)) return perfConverterCtr;
+  if (instrumentsRegex.test(line)) return instrumentsConverterCtr;
 
   throw new Error('Unable to detect input type for \n"' + line + '"');
 }

--- a/test/get-converter.js
+++ b/test/get-converter.js
@@ -17,6 +17,12 @@ test('\ngiven a perf stack info line (v3.18.7-200)', function (t) {
   t.end()
 })
 
+test('\ngiven a perf stack info line (v4.4.8)', function (t) {
+  var fn = getConverter([ 'node  2475 [001]  4049.771461:     250000 cpu-clock:u: '], 0);
+  t.equal(fn.name, 'PerfConverter', 'returns perf converter')
+  t.equal(fn.proto.type, 'perf', 'type is perf')
+  t.end()
+})
 
 test('\ngiven a dtrace stack info line', function (t) {
   var fn = getConverter([ 'iojs 86454 181016967: profile-1ms:'], 0);


### PR DESCRIPTION
The `perf script` output on my Ubuntu isn't supported by cpuprofilify.

```
$ perf --version
perf version 4.4.8

$ dpkg -S `which perf`
linux-tools-common: /usr/bin/perf

$ apt show linux-tools-common
Package: linux-tools-common
Version: 4.4.0-22.40
Priority: optional
Section: kernel
Source: linux
Origin: Ubuntu
Maintainer: Ubuntu Kernel Team <kernel-team@lists.ubuntu.com>
Bugs: https://bugs.launchpad.net/ubuntu/+filebug
Installed-Size: 297 kB
Supported: 5y
Download-Size: 113 kB
APT-Manual-Installed: yes
APT-Sources: http://security.ubuntu.com/ubuntu xenial-security/main amd64 Packages
Description: Linux kernel version specific tools for version 4.4.0
 This package provides the architecture independent parts for kernel
 version locked tools (such as perf and x86_energy_perf_policy) for
 version PGKVER.
```
